### PR TITLE
Add various features

### DIFF
--- a/inc/plugins/downloadthread.php
+++ b/inc/plugins/downloadthread.php
@@ -18,8 +18,17 @@ function downloadthread_info()
 
 function downloadthread_install()
 {
+    global $db, $cache, $groupscache;
+
     require_once "downloadthread/settings.php";
     downloadthread_settings_install();
+
+    if (!$db->field_exists('dlt_candlthread', 'usergroups')) {
+        // By default, all members can download threads
+        $db->add_column('usergroups', 'dlt_candlthread', "tinyint(1) NOT NULL DEFAULT '1'");
+        $cache->update_usergroups();
+        $groupscache = $cache->read('usergroups');
+    }
 }
 
 function downloadthread_is_installed()
@@ -33,16 +42,27 @@ function downloadthread_activate()
 {
     require_once "downloadthread/templates.php";
     downloadthread_templates_install();
+    require_once MYBB_ROOT.'/inc/adminfunctions_templates.php';
+    find_replace_templatesets('showthread', '({\\$addpoll})', "{\$addpoll}\n\t\t\t{\$downloadthread}");
 }
 
 function downloadthread_deactivate()
 {
+    require_once MYBB_ROOT.'/inc/adminfunctions_templates.php';
+    find_replace_templatesets('showthread', '(\\r?\\n\\t\\t\\t{\\$downloadthread})', '', 0);
     require_once "downloadthread/templates.php";
     downloadthread_templates_uninstall();
 }
 
 function downloadthread_uninstall()
 {
+    global $db, $cache, $groupscache;
+
     require_once "downloadthread/settings.php";
     downloadthread_settings_uninstall();
+    if ($db->field_exists('dlt_candlthread', 'usergroups')) {
+        $db->drop_column('usergroups', 'dlt_candlthread');
+        $cache->update_usergroups();
+        $groupscache = $cache->read('usergroups');
+    }
 }

--- a/inc/plugins/downloadthread/hooks.php
+++ b/inc/plugins/downloadthread/hooks.php
@@ -1,14 +1,26 @@
 <?php
 
-$plugins->add_hook("showthread_start", "downloadthread_showthread_start");
+$plugins->add_hook("showthread_start"             , "downloadthread_showthread_start"             );
+$plugins->add_hook("admin_formcontainer_end"      , "download_admin_formcontainer_end"            );
+$plugins->add_hook("admin_user_groups_edit_commit", "downloadthread_admin_user_groups_edit_commit");
 
 function downloadthread_showthread_start()
 {
-    global $mybb, $db, $forum;
-    if ($mybb->get_input("downloadthread", MyBB::INPUT_INT) == 1 && $mybb->request_method == "post" && verify_post_check($mybb->get_input("my_post_key")))
+    global $mybb, $db, $forum, $thread;
+    if($mybb->get_input("downloadthread", MyBB::INPUT_INT) == 1 && $mybb->request_method == "post" && verify_post_check($mybb->get_input("my_post_key")))
     {
+        if($mybb->settings['downloadthread_forums'] != -1 && !in_array($thread['fid'], explode(',', (string)$mybb->settings['downloadthread_forums'])))
+        {
+            /** @todo Create a language file and move all hard-coded strings like this into it. */
+            error('Thread downloading is disabled for this forum.');
+        }
+        else if(!$mybb->usergroup['dlt_candlthread'])
+        {
+            error('Your user group does not have permission to download threads.');
+        }
+
         $tid = $mybb->get_input("tid", MyBB::INPUT_INT);
-        $query = $db->simple_select("posts", "pid,username,dateline,message", "tid=" . $tid);
+        $query = $db->simple_select("posts", "pid,username,dateline,message", "tid=" . $tid, array("order_by" => "pid", "order_dir" => "asc"));
         $posts = array();
         if($mybb->get_input("format") == "json")
         {
@@ -16,7 +28,10 @@ function downloadthread_showthread_start()
             {
                 $posts[$post['pid']] = $post;
             }
-            $html = json_encode($posts);
+            $json = json_encode($posts);
+            $content = $json;
+            $contenttype = 'application/json';
+            $fname = 'thread-download.json';
         }
         else
         {
@@ -32,7 +47,6 @@ function downloadthread_showthread_start()
                 "filter_badwords" => 1
             );
 
-            global $thread;
             $html = "<html><head><title>" . $thread['subject'] . "</title></head><body><table border='1px solid black' width='80%'>";
             while($post = $db->fetch_array($query))
             {
@@ -43,8 +57,45 @@ function downloadthread_showthread_start()
                 $html .= "<td>" . $post['time'] . "</td></tr>";
             }
             $html .= "</table></body</html>";
+            $content = $html;
+            $contenttype = 'text/html';
+            $fname = 'thread-download.html';
         }
-        // TODO actually download the file.
         $db->free_result($query);
+
+        header('Content-Description: File Transfer');
+        header("Content-Disposition: attachment; filename=$fname");
+        header("Content-type: $contenttype");
+        echo $content;
+        exit;
     }
+    else
+    {
+        global $downloadthread;
+
+        $downloadthread = '<li style="background-image: none;">Download thread [<form method="post" action="showthread.php?downloadthread=1&amp;tid='.$thread['tid'].'" style="display: inline;"><input type="hidden" name="my_post_key" value="'.$mybb->post_code.'" /><input type="submit" style="background: none; border: none; color: #0072BC; font-family: Tahoma, Verdana, Arial, Sans-Serif; cursor: pointer; display: inline; margin: 0; padding: 0; font-size: 11px;" name="format" value="json" /> | <input type="submit" style="background: none; border: none; color: #0072BC; font-family: Tahoma, Verdana, Arial, Sans-Serif; cursor: pointer; display: inline; margin: 0; padding: 0; font-size: 11px;" name="format" value="html" /></form>]</li>';
+    }
+}
+
+function download_admin_formcontainer_end()
+{
+    global $mybb, $lang, $form, $form_container, $groupscache;
+
+    $gid = $mybb->get_input('gid', MyBB::INPUT_INT);
+    $usergroup = $groupscache[$gid];
+
+    $cbx_opts = array('id' => 'id_dlt_candlthread');
+    if ($usergroup['dlt_candlthread']) {
+        $cbx_opts['checked'] = true;
+    }
+    if (!empty($form_container->_title) && !empty($lang->forums_posts) && $form_container->_title == $lang->forums_posts) {
+        $form_container->output_row('Downloading Options', "", '<div class="group_settings_bit">'.$form->generate_check_box('dlt_candlthread', '1', "Can download threads?", $cbx_opts).'</div>');
+    }
+}
+
+function downloadthread_admin_user_groups_edit_commit()
+{
+    global $mybb, $updated_group;
+
+    $updated_group['dlt_candlthread'] = $mybb->get_input('dlt_candlthread', MyBB::INPUT_INT);
 }

--- a/inc/plugins/downloadthread/settings.php
+++ b/inc/plugins/downloadthread/settings.php
@@ -2,7 +2,45 @@
 
 function downloadthread_settings_install()
 {
+    global $db;
 
+    $res = $db->simple_select('settinggroups', 'MAX(disporder) as max_disporder');
+    $disporder = $db->fetch_field($res, 'max_disporder') + 1;
+    $fields = array(
+        'name'         => 'downloadthread_settings',
+        'title'        => 'Download Thread',
+        'description'  => 'Settings for the Download Thread plugin.',
+        'disporder'    => intval($disporder),
+        'isdefault'    => 0
+    );
+    $db->insert_query('settinggroups', $fields);
+    $gid = $db->insert_id();
+
+    $settings = array(
+        'forums' => array(
+            'title'       => 'Enabled Forums',
+            'description' => 'Select the forums from which threads may be downloaded.',
+            'optionscode' => 'forumselect',
+            'value'       => '-1',
+        ),
+    );
+    $ordernum = 1;
+    foreach ($settings as $name => $setting) {
+        $insert_settings = array(
+            'name'        => $db->escape_string('downloadthread_'.$name),
+            'title'       => $db->escape_string($setting['title'      ]),
+            'description' => $db->escape_string($setting['description']),
+            'optionscode' => $db->escape_string($setting['optionscode']),
+            'value'       => $db->escape_string($setting['value'      ]),
+            'disporder'   => $ordernum                                  ,
+            'gid'         => $gid                                       ,
+            'isdefault'   => 0
+        );
+        $db->insert_query('settings', $insert_settings);
+        $ordernum++;
+    }
+
+    rebuild_settings();
 }
 
 function downloadthread_settings_update()
@@ -12,5 +50,13 @@ function downloadthread_settings_update()
 
 function downloadthread_settings_uninstall()
 {
+    global $db;
 
+    $res = $db->simple_select('settinggroups', 'gid', "name = 'downloadthread_settings'");
+    while (($gid = $db->fetch_field($res, 'gid'))) {
+        $db->delete_query('settinggroups', "gid='{$gid}'");
+        $db->delete_query('settings'     , "gid='{$gid}'");
+        $needs_rebuild = true;
+    }
+    if ($needs_rebuild) rebuild_settings();
 }

--- a/inc/plugins/downloadthread/settings.php
+++ b/inc/plugins/downloadthread/settings.php
@@ -52,6 +52,7 @@ function downloadthread_settings_uninstall()
 {
     global $db;
 
+    $needs_rebuild = false;
     $res = $db->simple_select('settinggroups', 'gid', "name = 'downloadthread_settings'");
     while (($gid = $db->fetch_field($res, 'gid'))) {
         $db->delete_query('settinggroups', "gid='{$gid}'");


### PR DESCRIPTION
* Add a plugin setting for admins to stipulate forums on which
downloading threads is permitted.

* Add a usergroup setting for admins to stipulate which usergroups are
permitted to download threads.

* Add download functionality to the existing generation of downloadable
content.

* Add ascending ordering by pid to the query to select posts.